### PR TITLE
Remove redundant code

### DIFF
--- a/examples/MilvusClientExample.go
+++ b/examples/MilvusClientExample.go
@@ -57,9 +57,7 @@ func example(address string, port string) {
 	println("Server status: connected")
 
 	//Get server version
-	var version string
-	var status milvus.Status
-	version, status, err = client.ServerVersion()
+	version, status, err := client.ServerVersion()
 	if err != nil {
 		println("Cmd rpc failed: " + err.Error())
 	}
@@ -71,25 +69,17 @@ func example(address string, port string) {
 
 	//test create collection
 	collectionParam := milvus.CollectionParam{collectionName, dimension, indexFileSize, metricType}
-	var hasCollection bool
-	//hasCollection, status, err = client.HasCollection(collectionName)
+	status, err = client.CreateCollection(collectionParam)
 	if err != nil {
-		println("HasCollection rpc failed: " + err.Error())
+		println("CreateCollection rpc failed: " + err.Error())
+		return
 	}
-	if hasCollection == false {
-		status, err = client.CreateCollection(collectionParam)
-		if err != nil {
-			println("CreateCollection rpc failed: " + err.Error())
-			return
-		}
-		if !status.Ok() {
-			println("Create collection failed: " + status.GetMessage())
-			return
-		}
-		println("Create collection " + collectionName + " success")
+	if !status.Ok() {
+		println("Create collection failed: " + status.GetMessage())
+		return
 	}
-
-	hasCollection, status, err = client.HasCollection(collectionName)
+	println("Create collection " + collectionName + " success")
+	hasCollection, status, err := client.HasCollection(collectionName)
 	if err != nil {
 		println("HasCollection rpc failed: " + err.Error())
 		return
@@ -103,8 +93,7 @@ func example(address string, port string) {
 	println("**************************************************")
 
 	//test show collections
-	var collections []string
-	collections, status, err = client.ListCollections()
+	collections, status, err := client.ListCollections()
 	if err != nil {
 		println("ShowCollections rpc failed: " + err.Error())
 		return
@@ -172,10 +161,9 @@ func example(address string, port string) {
 	println("**************************************************")
 
 	//Search without create index
-	var topkQueryResult milvus.TopkQueryResult
 	extraParams := "{\"nprobe\" : 32}"
 	searchParam := milvus.SearchParam{collectionName, queryRecords, topk, nil, extraParams}
-	topkQueryResult, status, err = client.Search(searchParam)
+	topkQueryResult, status, err := client.Search(searchParam)
 	if err != nil {
 		println("Search rpc failed: " + err.Error())
 	}
@@ -189,8 +177,7 @@ func example(address string, port string) {
 	println("**************************************************")
 
 	//test CountCollection
-	var collectionCount int64
-	collectionCount, status, err = client.CountEntities(collectionName)
+	collectionCount, status, err := client.CountEntities(collectionName)
 	if err != nil {
 		println("CountCollection rpc failed: " + err.Error())
 		return
@@ -280,8 +267,7 @@ func example(address string, port string) {
 	println("Drop collection " + collectionName + " success!")
 
 	//GetConfig
-	var configInfo string
-	configInfo, status, err = client.GetConfig("*")
+	configInfo, status, err := client.GetConfig("*")
 	if !status.Ok() {
 		println("Get config failed: " + status.GetMessage())
 	}
@@ -297,8 +283,7 @@ func example(address string, port string) {
 	println("Client disconnect server success!")
 
 	//Server status
-	var serverStatus string
-	serverStatus, status, err = client.ServerStatus()
+	serverStatus, status, err := client.ServerStatus()
 	if !status.Ok() {
 		println("Get server status failed: " + status.GetMessage())
 	}

--- a/milvus/ClientProxy.go
+++ b/milvus/ClientProxy.go
@@ -72,7 +72,7 @@ func (client *Milvusclient) Connect(connectParam ConnectParam) error {
 		println("Get server version status: " + status.GetMessage())
 		return err
 	}
-	if (serverVersion[0:4] != "0.10") {
+	if serverVersion[0:4] != "0.10" {
 		println("Server version check failed, this client supposed to connect milvus-0.10.x")
 		client.Instance = nil
 		err = errors.New("Connecto server failed, please check server version.")
@@ -169,7 +169,7 @@ func (client *Milvusclient) GetEntityByID(collectionName string, vector_id []int
 		entityLen := len(grpcVectorData.VectorsData)
 		var entity = make([]Entity, entityLen)
 		var i int64
-		for i = 0;i < int64(entityLen); i++ {
+		for i = 0; i < int64(entityLen); i++ {
 			entity[i].FloatData = grpcVectorData.VectorsData[i].FloatData
 			entity[i].BinaryData = grpcVectorData.VectorsData[i].BinaryData
 		}
@@ -211,7 +211,7 @@ func (client *Milvusclient) Search(searchParam SearchParam) (TopkQueryResult, St
 	}
 	nq := topkQueryResult.GetRowNum()
 	if nq == 0 {
-		return TopkQueryResult{nil}, status{int64(topkQueryResult.Status.ErrorCode), topkQueryResult.Status.Reason,}, err
+		return TopkQueryResult{nil}, status{int64(topkQueryResult.Status.ErrorCode), topkQueryResult.Status.Reason}, err
 	}
 	var queryResult []QueryResult
 	topk := int64(len(topkQueryResult.GetIds())) / nq

--- a/milvus/MilvusClient.go
+++ b/milvus/MilvusClient.go
@@ -17,10 +17,7 @@
  * under the License.
  */
 
-// package milvus
 package milvus
-
-import ()
 
 var clientVersion string = "0.4.0"
 

--- a/milvus/MilvusGrpcClient.go
+++ b/milvus/MilvusGrpcClient.go
@@ -92,7 +92,7 @@ func (grpcClient *milvusGrpcClient) CreateCollection(collectionSchema pb.Collect
 	defer cancel()
 	reply, err := grpcClient.serviceInstance.CreateCollection(ctx, &collectionSchema)
 	if err != nil {
-		return pb.Status{0, "", struct{}{}, nil, 0,}, err
+		return pb.Status{0, "", struct{}{}, nil, 0}, err
 	}
 	return *reply, err
 }
@@ -102,7 +102,7 @@ func (grpcClient *milvusGrpcClient) HasCollection(collectionName pb.CollectionNa
 	defer cancel()
 	boolReply, err := grpcClient.serviceInstance.HasCollection(ctx, &collectionName)
 	if err != nil {
-		return pb.BoolReply{nil, false, struct{}{}, nil, 0,}, err
+		return pb.BoolReply{nil, false, struct{}{}, nil, 0}, err
 	}
 	return *boolReply, err
 }
@@ -112,7 +112,7 @@ func (grpcClient *milvusGrpcClient) DescribeCollection(collectionName pb.Collect
 	defer cancel()
 	collectionSchema, err := grpcClient.serviceInstance.DescribeCollection(ctx, &collectionName)
 	if err != nil {
-		return pb.CollectionSchema{nil, "", 0, 0, 0, nil, struct{}{}, nil, 0,}, err
+		return pb.CollectionSchema{nil, "", 0, 0, 0, nil, struct{}{}, nil, 0}, err
 	}
 	return *collectionSchema, err
 }
@@ -122,7 +122,7 @@ func (grpcClient *milvusGrpcClient) CountCollection(collectionName pb.Collection
 	defer cancel()
 	count, err := grpcClient.serviceInstance.CountCollection(ctx, &collectionName)
 	if err != nil {
-		return pb.CollectionRowCount{nil, 0, struct{}{}, nil, 0,}, err
+		return pb.CollectionRowCount{nil, 0, struct{}{}, nil, 0}, err
 	}
 	return *count, err
 }
@@ -133,7 +133,7 @@ func (grpcClient *milvusGrpcClient) ShowCollections() (pb.CollectionNameList, er
 	defer cancel()
 	collectionNameList, err := grpcClient.serviceInstance.ShowCollections(ctx, &cmd)
 	if err != nil {
-		return pb.CollectionNameList{nil, nil, struct{}{}, nil, 0,}, err
+		return pb.CollectionNameList{nil, nil, struct{}{}, nil, 0}, err
 	}
 	return *collectionNameList, err
 }
@@ -143,7 +143,7 @@ func (grpcClient *milvusGrpcClient) ShowCollectionInfo(collectionName pb.Collect
 	defer cancel()
 	collectionInfo, err := grpcClient.serviceInstance.ShowCollectionInfo(ctx, &collectionName)
 	if err != nil {
-		return pb.CollectionInfo{nil, "", struct{}{}, nil, 0,}, err
+		return pb.CollectionInfo{nil, "", struct{}{}, nil, 0}, err
 	}
 	return *collectionInfo, err
 }
@@ -153,7 +153,7 @@ func (grpcClient *milvusGrpcClient) DropCollection(collectionName pb.CollectionN
 	defer cancel()
 	status, err := grpcClient.serviceInstance.DropCollection(ctx, &collectionName)
 	if err != nil {
-		return pb.Status{0, "", struct{}{}, nil, 0,}, err
+		return pb.Status{0, "", struct{}{}, nil, 0}, err
 	}
 	return *status, err
 }
@@ -162,7 +162,7 @@ func (grpcClient *milvusGrpcClient) CreateIndex(indexParam pb.IndexParam) (pb.St
 	ctx := context.Background()
 	status, err := grpcClient.serviceInstance.CreateIndex(ctx, &indexParam)
 	if err != nil {
-		return pb.Status{0, "", struct{}{}, nil, 0,}, err
+		return pb.Status{0, "", struct{}{}, nil, 0}, err
 	}
 	return *status, err
 }
@@ -172,7 +172,7 @@ func (grpcClient *milvusGrpcClient) DescribeIndex(collectionName pb.CollectionNa
 	defer cancel()
 	indexParam, err := grpcClient.serviceInstance.DescribeIndex(ctx, &collectionName)
 	if err != nil {
-		return pb.IndexParam{nil, "", 0, nil, struct{}{}, nil, 0,}, err
+		return pb.IndexParam{nil, "", 0, nil, struct{}{}, nil, 0}, err
 	}
 	return *indexParam, err
 }
@@ -182,7 +182,7 @@ func (grpcClient *milvusGrpcClient) DropIndex(collectionName pb.CollectionName) 
 	defer cancel()
 	status, err := grpcClient.serviceInstance.DropIndex(ctx, &collectionName)
 	if err != nil {
-		return pb.Status{0, "", struct{}{}, nil, 0,}, err
+		return pb.Status{0, "", struct{}{}, nil, 0}, err
 	}
 	return *status, err
 }
@@ -192,7 +192,7 @@ func (grpcClient *milvusGrpcClient) CreatePartition(partitionParam pb.PartitionP
 	defer cancel()
 	status, err := grpcClient.serviceInstance.CreatePartition(ctx, &partitionParam)
 	if err != nil {
-		return pb.Status{0, "", struct{}{}, nil, 0,}, err
+		return pb.Status{0, "", struct{}{}, nil, 0}, err
 	}
 	return *status, err
 }
@@ -202,7 +202,7 @@ func (grpcClient *milvusGrpcClient) ShowPartitions(collectionName pb.CollectionN
 	defer cancel()
 	status, err := grpcClient.serviceInstance.ShowPartitions(ctx, &collectionName)
 	if err != nil {
-		return pb.PartitionList{nil, nil, struct{}{}, nil, 0,}, err
+		return pb.PartitionList{nil, nil, struct{}{}, nil, 0}, err
 	}
 	return *status, err
 }
@@ -212,7 +212,7 @@ func (grpcClient *milvusGrpcClient) DropPartition(partitionParam pb.PartitionPar
 	defer cancel()
 	status, err := grpcClient.serviceInstance.DropPartition(ctx, &partitionParam)
 	if err != nil {
-		return pb.Status{0, "", struct{}{}, nil, 0,}, err
+		return pb.Status{0, "", struct{}{}, nil, 0}, err
 	}
 	return *status, err
 }
@@ -221,7 +221,7 @@ func (grpcClient *milvusGrpcClient) Insert(insertParam pb.InsertParam) (pb.Vecto
 	ctx := context.Background()
 	vectorIds, err := grpcClient.serviceInstance.Insert(ctx, &insertParam)
 	if err != nil {
-		return pb.VectorIds{nil, nil, struct{}{}, nil, 0,}, err
+		return pb.VectorIds{nil, nil, struct{}{}, nil, 0}, err
 	}
 	return *vectorIds, err
 }
@@ -230,7 +230,7 @@ func (grpcClient *milvusGrpcClient) GetVectorsByID(identity pb.VectorsIdentity) 
 	ctx := context.Background()
 	vectorsData, err := grpcClient.serviceInstance.GetVectorsByID(ctx, &identity)
 	if err != nil {
-		return pb.VectorsData{nil, nil, struct{}{}, nil, 0,}, err
+		return pb.VectorsData{nil, nil, struct{}{}, nil, 0}, err
 	}
 	return *vectorsData, err
 }
@@ -239,7 +239,7 @@ func (grpcClient *milvusGrpcClient) GetVectorIDs(param pb.GetVectorIDsParam) (pb
 	ctx := context.Background()
 	status, err := grpcClient.serviceInstance.GetVectorIDs(ctx, &param)
 	if err != nil {
-		return pb.VectorIds{nil, nil, struct{}{}, nil, 0,}, err
+		return pb.VectorIds{nil, nil, struct{}{}, nil, 0}, err
 	}
 	return *status, err
 }
@@ -248,7 +248,7 @@ func (grpcClient *milvusGrpcClient) Search(searchParam pb.SearchParam) (*pb.TopK
 	ctx := context.Background()
 	topkQueryResult, err := grpcClient.serviceInstance.Search(ctx, &searchParam)
 	if err != nil {
-		return &pb.TopKQueryResult{nil, 0, nil, nil, struct{}{}, nil, 0,}, err
+		return &pb.TopKQueryResult{nil, 0, nil, nil, struct{}{}, nil, 0}, err
 	}
 	return topkQueryResult, err
 }
@@ -257,7 +257,7 @@ func (grpcClient *milvusGrpcClient) SearchInFiles(searchInFilesParam pb.SearchIn
 	ctx := context.Background()
 	topkQueryResult, err := grpcClient.serviceInstance.SearchInFiles(ctx, &searchInFilesParam)
 	if err != nil {
-		return &pb.TopKQueryResult{nil, 0, nil, nil, struct{}{}, nil, 0,}, err
+		return &pb.TopKQueryResult{nil, 0, nil, nil, struct{}{}, nil, 0}, err
 	}
 	return topkQueryResult, err
 }
@@ -267,7 +267,7 @@ func (grpcClient *milvusGrpcClient) Cmd(command pb.Command) (pb.StringReply, err
 	defer cancel()
 	stringReply, err := grpcClient.serviceInstance.Cmd(ctx, &command)
 	if err != nil {
-		return pb.StringReply{nil, "", struct{}{}, nil, 0,}, err
+		return pb.StringReply{nil, "", struct{}{}, nil, 0}, err
 	}
 	return *stringReply, err
 }
@@ -277,7 +277,7 @@ func (grpcClient *milvusGrpcClient) DeleteByID(param pb.DeleteByIDParam) (pb.Sta
 	defer cancel()
 	status, err := grpcClient.serviceInstance.DeleteByID(ctx, &param)
 	if err != nil {
-		return pb.Status{0, "", struct{}{}, nil, 0,}, err
+		return pb.Status{0, "", struct{}{}, nil, 0}, err
 	}
 	return *status, err
 }
@@ -287,7 +287,7 @@ func (grpcClient *milvusGrpcClient) PreloadCollection(collectionName pb.Collecti
 	defer cancel()
 	status, err := grpcClient.serviceInstance.PreloadCollection(ctx, &collectionName)
 	if err != nil {
-		return pb.Status{0, "", struct{}{}, nil, 0,}, err
+		return pb.Status{0, "", struct{}{}, nil, 0}, err
 	}
 	return *status, err
 }
@@ -297,7 +297,7 @@ func (grpcClient *milvusGrpcClient) Flush(param pb.FlushParam) (pb.Status, error
 	defer cancel()
 	status, err := grpcClient.serviceInstance.Flush(ctx, &param)
 	if err != nil {
-		return pb.Status{0, "", struct{}{}, nil, 0,}, err
+		return pb.Status{0, "", struct{}{}, nil, 0}, err
 	}
 	return *status, err
 }
@@ -307,7 +307,7 @@ func (grpcClient *milvusGrpcClient) Compact(collectionName pb.CollectionName) (p
 	defer cancel()
 	status, err := grpcClient.serviceInstance.Compact(ctx, &collectionName)
 	if err != nil {
-		return pb.Status{0, "", struct{}{}, nil, 0,}, err
+		return pb.Status{0, "", struct{}{}, nil, 0}, err
 	}
 	return *status, err
 }


### PR DESCRIPTION
1. Remove redundant code in `MilvusClientExample.go`

2. Use `go fmt` to format the code