### PR TITLE
Hide Connect method

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -27,9 +27,7 @@ import (
 //		}
 //		// start doing things with client instance, note that there is no need to call Connect since NewXXXClient will do that for you
 type Client interface {
-	// Connect connect to the address provided
-	Connect(ctx context.Context, addr string) error
-	// Close close the remaining connection
+	// Close close the remaining connection resources
 	Close() error
 
 	// -- collection --
@@ -122,10 +120,7 @@ const (
 // dialOptions contains the dial option(s) that control the grpc dialing process
 func NewGrpcClient(ctx context.Context, addr string, dialOptions ...grpc.DialOption) (Client, error) {
 	c := &grpcClient{}
-	// since different client may have different type of connect option(s), it's hard to put concrete type in Connect method def
-	// interface{} is ugly, so use context value may be a solution
-	ctx = context.WithValue(ctx, dialOption, dialOptions)
-	err := c.Connect(ctx, addr)
+	err := c.connect(ctx, addr, dialOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/client/client_grpc_collection.go
+++ b/client/client_grpc_collection.go
@@ -30,20 +30,10 @@ type grpcClient struct {
 	service server.MilvusServiceClient // service client stub
 }
 
-// Connect connect to service
-func (c *grpcClient) Connect(ctx context.Context, addr string) error {
-	opts := make([]grpc.DialOption, 0, 10)
+// connect connect to service
+func (c *grpcClient) connect(ctx context.Context, addr string, opts ...grpc.DialOption) error {
 
-	// try parse DialOptions
-	cOptsRaw := ctx.Value(dialOption)
-	if cOptsRaw != nil {
-		cOpts, ok := cOptsRaw.([]grpc.DialOption)
-		if ok {
-			opts = append(opts, cOpts...)
-		}
-	}
-
-	// if not options detected, use default
+	// if not options provided, use default settings
 	if len(opts) == 0 {
 		opts = append(opts, grpc.WithInsecure(),
 			grpc.WithBlock(),                //block connect until healthy or timeout


### PR DESCRIPTION
Hide `Connect` from Client interface
Connect behavior shall be invoked int `NewXXXClient` method. Thus different connection options can be explicitly specified.

Fix issue: #172 

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>