### PR TITLE
add schema table for collection creation in docs

### DIFF
--- a/docs/create_collection.md
+++ b/docs/create_collection.md
@@ -10,6 +10,18 @@ API to create collection according to the specified schema.
 | `collSchema` | Collection schema definition                                 | Pointer of entity.Schema |
 | `shardNum`   | Shard number of the collection to create. If the `shardNum` is set to 0, default shard number, i.e. 2, will be used. | INT32   |
 
+
+## Schema Structure
+
+The schema represents the schema info of the collection in milvus , the schema structure is shown below
+
+| Parameter |  Type |   Description |
+| --------- | ------ | ---------- |
+| `Collection Name` | string | Name given to the collection |
+| `Description` | string | Description given to collection |
+| `AutoID` | boolean | The auto id of the collection |
+| `Fields` | [Field Schema of milvus](https://github.com/milvus-io/milvus-sdk-go/blob/7410632233597d4af58df727682ffb29f1d1d51d/entity/schema.go#L54-L63) | Contains various fields for the schema  |
+
 ## Response
 
 `err`: error in the creation process (if any). Possible errors are listed below:


### PR DESCRIPTION
This works on the issue #191  

Added the schema structure in a table in  the create_collection.md in the docs

Describes the various fields of the schema required and type of each field