### PR TITLE
ServerStatus: actually issue "status" command

### DIFF
--- a/milvus/ClientProxy.go
+++ b/milvus/ClientProxy.go
@@ -354,12 +354,12 @@ func (client *Milvusclient) ServerStatus(ctx context.Context) (string, Status, e
 	if client.Instance == nil {
 		return "not connect to server", status{int64(0), ""}, nil
 	}
-	command := pb.Command{Cmd: ""}
+	command := pb.Command{Cmd: "status"}
 	serverStatus, err := client.Instance.Cmd(ctx, command)
 	if err != nil {
 		return "connection lost", nil, err
 	}
-	return "server alive", status{int64(serverStatus.GetStatus().GetErrorCode()), serverStatus.GetStatus().GetReason()}, err
+	return serverStatus.GetStringReply(), status{int64(serverStatus.GetStatus().GetErrorCode()), serverStatus.GetStatus().GetReason()}, err
 }
 
 ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Changing ServerStatus method to use actual `"status"` command so it behaves like [python client](https://github.com/milvus-io/pymilvus/blob/1.x/milvus/client/grpc_handler.py#L251) (and possibly others) and starts working with Mishards.

Fixes: #225