### PR TITLE
Remove test teardown clear all collections

### DIFF
--- a/test/testcases/main_test.go
+++ b/test/testcases/main_test.go
@@ -35,10 +35,6 @@ func teardown() {
 		log.Fatalf("teardown failed to connect milvus with error %v", err)
 	}
 	defer mc.Close()
-	collections, _ := mc.ListCollections(ctx)
-	for _, collection := range collections {
-		mc.DropCollection(ctx, collection.Name)
-	}
 }
 
 //


### PR DESCRIPTION
- Remove test teardown clear all collections

In order not to drop their collections when running with other types of tests

/kind improvement