### PR TITLE
fix(client): interface GetIndexBuildProgress miss

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -107,6 +107,8 @@ type Client interface {
 	// GetIndexState get index state with specified collection and field name
 	// index naming is not supported yet
 	GetIndexState(ctx context.Context, collName string, fieldName string, opts ...IndexOption) (entity.IndexState, error)
+	// GetIndexBuildProgress get index building progress
+	GetIndexBuildProgress(ctx context.Context, collName string, fieldName string, opts ...IndexOption) (total, indexed int64, err error)
 
 	// -- basic operation --
 


### PR DESCRIPTION
The public method is not included in the `Client` interface, so it cannot be used for the created instance.
The same for `v2.2.x`.