### PR TITLE
[Enhancement] use grpc.DialContext in client.NewClient

### DIFF
--- a/client/collection.go
+++ b/client/collection.go
@@ -42,7 +42,7 @@ func (c *GrpcClient) connect(ctx context.Context, addr string, opts ...grpc.Dial
 	if addr == "" {
 		return fmt.Errorf("address is empty")
 	}
-	conn, err := grpc.Dial(addr, opts...)
+	conn, err := grpc.DialContext(ctx, addr, opts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Use `grpc.DialContext` in `client.NewClient`.
Allow user to determine the cancelation or timeout of connect operation.