### PR TITLE
[2.2.x] Support struct field to json

### DIFF
--- a/entity/columns_json_test.go
+++ b/entity/columns_json_test.go
@@ -67,6 +67,12 @@ func (s *ColumnJSONBytesSuite) TestAttrMethods() {
 		s.NoError(err)
 		s.Equal(item, val)
 
+		err = column.AppendValue(&struct{ Tag string }{Tag: "abc"})
+		s.NoError(err)
+
+		err = column.AppendValue(map[string]interface{}{"Value": 123})
+		s.NoError(err)
+
 		err = column.AppendValue(1)
 		s.Error(err)
 	})


### PR DESCRIPTION
Make following field possible to insert as json field
``` go
type Row struct {
//...
    JSON Meta `milvus:"name:json"`// json is a json data_type column
}
type Meta struct {
// ...
}
```

See also milvus-io/milvus#24232
/kind improvement