### PR TITLE
Revert "feat: support enabling mmap for collection (#632)"

### DIFF
--- a/entity/collection_attr.go
+++ b/entity/collection_attr.go
@@ -22,7 +22,6 @@ const (
 	cakTTL = `collection.ttl.seconds`
 	// cakAutoCompaction const for collection attribute key autom compaction enabled.
 	cakAutoCompaction = `collection.autocompaction.enabled`
-	akMmap            = "mmap.enabled"
 )
 
 // CollectionAttribute is the interface for altering collection attributes.
@@ -89,24 +88,4 @@ func CollectionAutoCompactionEnabled(enabled bool) autoCompactionCollAttr {
 	ca.key = cakAutoCompaction
 	ca.value = strconv.FormatBool(enabled)
 	return ca
-}
-
-type mmapAttr struct {
-	collAttrBase
-}
-
-func Mmap(enabled bool) mmapAttr {
-	attr := mmapAttr{}
-	attr.key = akMmap
-	attr.value = strconv.FormatBool(enabled)
-	return attr
-}
-
-func (ca mmapAttr) Valid() error {
-	_, err := strconv.ParseBool(ca.value)
-	if err != nil {
-		return errors.Wrap(err, "mmap setting is not valid boolean")
-	}
-
-	return nil
 }


### PR DESCRIPTION
This reverts commit 83f95d7ff26131c37e8ac7daf4a63013549b40cf.