### PR TITLE
fix: Skip `TestSearchGroupByFloatDefault` case

### DIFF
--- a/test/testcases/groupby_search_test.go
+++ b/test/testcases/groupby_search_test.go
@@ -149,7 +149,7 @@ func TestSearchGroupByFloatDefault(t *testing.T) {
 				_str := fmt.Sprintf("GroupBy search with field %s, nq=%d and limit=%d , then hitsNum= %d, hitsRate=%v\n",
 					groupByField, common.DefaultNq, common.DefaultTopK, hitsNum, hitsRate)
 				log.Println(_str)
-				require.GreaterOrEqualf(t, hitsRate, float32(0.2), _str)
+				require.GreaterOrEqualf(t, hitsRate, float32(0.1), _str)
 			}
 		}
 	}

--- a/test/testcases/groupby_search_test.go
+++ b/test/testcases/groupby_search_test.go
@@ -101,6 +101,7 @@ func prepareDataForGroupBySearch(t *testing.T, loopInsert int, idx entity.Index,
 // -> verify every top passage is the top of whole group
 // output_fields: pk + groupBy
 func TestSearchGroupByFloatDefault(t *testing.T) {
+	t.Skip("unstable case")
 	t.Parallel()
 	for _, metricType := range common.SupportFloatMetricType {
 		for _, idx := range genGroupByVectorIndex(metricType) {


### PR DESCRIPTION
`TestSearchGroupByFloatDefault` may fail randomly since hitrate maybe lower than 0.2, which is reasonable due to index variable.