### PR TITLE
fix: Use corrent place holder type for fp16 vector

### DIFF
--- a/client/insert.go
+++ b/client/insert.go
@@ -511,7 +511,7 @@ func vector2Placeholder(vectors []entity.Vector) *commonpb.PlaceholderValue {
 	case entity.BFloat16Vector:
 		placeHolderType = commonpb.PlaceholderType_BFloat16Vector
 	case entity.Float16Vector:
-		placeHolderType = commonpb.PlaceholderType_FloatVector
+		placeHolderType = commonpb.PlaceholderType_Float16Vector
 	case entity.SparseEmbedding:
 		placeHolderType = commonpb.PlaceholderType_SparseFloatVector
 	}


### PR DESCRIPTION
This place holder type was set to FloatVector by mistake. This PR rectify the value for fp16 vector.