### PR TITLE
fix: Pass index type for Scalar indexes

### DIFF
--- a/entity/index_scalar.go
+++ b/entity/index_scalar.go
@@ -7,7 +7,9 @@ type indexScalar struct {
 }
 
 func (i *indexScalar) Params() map[string]string {
-	return map[string]string{}
+	return map[string]string{
+		tIndexType: string(i.baseIndex.it),
+	}
 }
 
 func NewScalarIndex() Index {

--- a/entity/index_scalar.go
+++ b/entity/index_scalar.go
@@ -7,9 +7,11 @@ type indexScalar struct {
 }
 
 func (i *indexScalar) Params() map[string]string {
-	return map[string]string{
-		tIndexType: string(i.baseIndex.it),
+	result := make(map[string]string)
+	if i.baseIndex.it != "" {
+		result[tIndexType] = string(i.baseIndex.it)
 	}
+	return result
 }
 
 func NewScalarIndex() Index {

--- a/entity/index_scalar_test.go
+++ b/entity/index_scalar_test.go
@@ -14,4 +14,10 @@ func TestScalarIndex(t *testing.T) {
 	idxWithType := NewScalarIndexWithType(Sorted)
 
 	assert.EqualValues(t, Sorted, idxWithType.IndexType())
+	assert.EqualValues(t, Sorted, idxWithType.Params()[tIndexType])
+
+	idxWithType = NewScalarIndexWithType(Trie)
+
+	assert.EqualValues(t, Trie, idxWithType.IndexType())
+	assert.EqualValues(t, Trie, idxWithType.Params()[tIndexType])
 }

--- a/entity/index_scalar_test.go
+++ b/entity/index_scalar_test.go
@@ -10,6 +10,8 @@ func TestScalarIndex(t *testing.T) {
 	oldScalarIdx := NewScalarIndex()
 
 	assert.EqualValues(t, "", oldScalarIdx.IndexType(), "use AUTO index when index type not provided")
+	_, has := oldScalarIdx.Params()[tIndexType]
+	assert.False(t, has)
 
 	idxWithType := NewScalarIndexWithType(Sorted)
 


### PR DESCRIPTION
Related to #694 #695