### PR TITLE
enhance: Add Describe User methods

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -188,7 +188,11 @@ type Client interface {
 	ListRoles(ctx context.Context) ([]entity.Role, error)
 	// ListUsers lists the user objects in system.
 	ListUsers(ctx context.Context) ([]entity.User, error)
-	// Grant adds object privileged for role.
+	// DescribeUser describes specific user attributes in the system
+	DescribeUser(ctx context.Context, username string) (entity.UserDescription, error)
+	// DescribeUsers describe all users attributes in the system
+	DescribeUsers(ctx context.Context) ([]entity.UserDescription, error)
+	// Grant adds privilege for role.
 	Grant(ctx context.Context, role string, objectType entity.PriviledgeObjectType, object string) error
 	// Revoke removes privilege from role.
 	Revoke(ctx context.Context, role string, objectType entity.PriviledgeObjectType, object string) error

--- a/client/rbac.go
+++ b/client/rbac.go
@@ -97,6 +97,7 @@ func (c *GrpcClient) RemoveUserRole(ctx context.Context, username string, role s
 	if err != nil {
 		return err
 	}
+
 	return handleRespStatus(resp)
 }
 

--- a/client/rbac.go
+++ b/client/rbac.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"context"
+
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-sdk-go/v2/entity"

--- a/entity/rbac.go
+++ b/entity/rbac.go
@@ -1,8 +1,6 @@
 package entity
 
-import (
-	common "github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
-)
+import common "github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 
 // User is the model for RBAC user object.
 type User struct {

--- a/entity/rbac.go
+++ b/entity/rbac.go
@@ -1,10 +1,18 @@
 package entity
 
-import common "github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+import (
+	common "github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+)
 
 // User is the model for RBAC user object.
 type User struct {
 	Name string
+}
+
+// UserDescription is the model for RBAC user description object.
+type UserDescription struct {
+	Name  string
+	Roles []string
 }
 
 // Role is the model for RBAC role object.


### PR DESCRIPTION
resolves: #698

I've added an entity:

```
type UserDescription struct {
	Name  string
	Roles []string
}
```

And two methods and tests for them:

- `DescribeUser(ctx context.Context, username string) (entity.UserDescription, error)` - which returns UserDescription for a specific user.
- `DescribeUsers(ctx context.Context) ([]entity.UserDescription, error)` - which returns UserDescription for all users presented. 

The thing that I want to raise is that I am not sure if it is feasible to return empty `UserDescription` entity in case the user from `DescribeUser` method doesn't exist, I would highly appreciate suggestions here.

Also, I am not much familiar with the `milvus-sdk-go` codebase and this is my first PR here, so any comments/feedback/suggestions would be highly appreciated, thanks!