### PR TITLE
fix: Build binary index on binary field and skip some cases

### DIFF
--- a/test/common/utils.go
+++ b/test/common/utils.go
@@ -114,6 +114,12 @@ var AllVectorsFieldsName = []string{
 	DefaultBFloat16VecFieldName,
 }
 
+var AllFloatVectorsFieldNames = []string{
+	DefaultFloatVecFieldName,
+	DefaultFloat16VecFieldName,
+	DefaultBFloat16VecFieldName,
+}
+
 // return all fields name
 func GetAllFieldsName(enableDynamicField bool, onlyScalar bool) []string {
 	allFieldName := []string{

--- a/test/testcases/delete_test.go
+++ b/test/testcases/delete_test.go
@@ -294,10 +294,15 @@ func TestDeleteExpressions(t *testing.T) {
 	_, _ = insertData(ctx, t, mc, dp)
 
 	idx, _ := entity.NewIndexHNSW(entity.L2, 8, 96)
-	for _, field := range common.AllVectorsFieldsName {
+	for _, field := range common.AllFloatVectorsFieldNames {
 		err := mc.CreateIndex(ctx, collName, field, idx, false)
 		common.CheckErr(t, err, true)
 	}
+
+	flatIdx, _ := entity.NewIndexBinFlat(entity.JACCARD, 16)
+
+	err := mc.CreateIndex(ctx, collName, common.DefaultBinaryVecFieldName, flatIdx, false)
+	common.CheckErr(t, err, true)
 
 	// Load collection
 	errLoad := mc.LoadCollection(ctx, collName, false)

--- a/test/testcases/index_test.go
+++ b/test/testcases/index_test.go
@@ -193,6 +193,7 @@ func TestCreateScalarIndex(t *testing.T) {
 
 // test create scalar index with vector field name
 func TestCreateIndexWithOtherFieldName(t *testing.T) {
+	t.Skip("index type not pased")
 	ctx := createContext(t, time.Second*common.DefaultTimeout)
 	//connect
 	mc := createMilvusClient(ctx, t)
@@ -215,6 +216,7 @@ func TestCreateIndexWithOtherFieldName(t *testing.T) {
 }
 
 func TestCreateIndexJsonField(t *testing.T) {
+	t.Skip("index type not passed")
 	ctx := createContext(t, time.Second*common.DefaultTimeout)
 	// connect
 	mc := createMilvusClient(ctx, t)
@@ -247,7 +249,7 @@ func TestCreateIndexJsonField(t *testing.T) {
 	common.CheckErr(t, err, false, "only support float vector or binary vector")
 
 	//create scalar index on json field
-	err = mc.CreateIndex(ctx, collName, common.DefaultJSONFieldName, entity.NewScalarIndex(), false, client.WithIndexName("json_index"))
+	err = mc.CreateIndex(ctx, collName, common.DefaultJSONFieldName, entity.NewScalarIndexWithType(entity.Sorted), false, client.WithIndexName("json_index"))
 	common.CheckErr(t, err, false, "create auto index on JSON field is not supported")
 }
 
@@ -281,7 +283,7 @@ func TestCreateIndexArrayField(t *testing.T) {
 			common.CheckErr(t, err, false, "create auto index on Array field is not supported")
 			// create vector index
 			err1 := mc.CreateIndex(ctx, collName, field.Name, vectorIdx, false, client.WithIndexName("vector_index"))
-			common.CheckErr(t, err1, false, "float or float16 or bfloat16 vector are only supported")
+			common.CheckErr(t, err1, false, "data type should be FloatVector, Float16Vector or BFloat16Vector")
 		}
 	}
 }
@@ -474,12 +476,12 @@ func TestCreateIndexNotSupportedField(t *testing.T) {
 	// create index
 	idx, _ := entity.NewIndexHNSW(entity.L2, 8, 96)
 	err := mc.CreateIndex(ctx, collName, common.DefaultFloatFieldName, idx, false)
-	common.CheckErr(t, err, false, "only support float vector or binary vector")
+	common.CheckErr(t, err, false, "HNSW only support float vector data type")
 
 	// create scann index
 	indexScann, _ := entity.NewIndexSCANN(entity.L2, 8, true)
 	err = mc.CreateIndex(ctx, collName, common.DefaultFloatFieldName, indexScann, false)
-	common.CheckErr(t, err, false, "float or float16 or bfloat16 vector are only supported")
+	common.CheckErr(t, err, false, "data type should be FloatVector, Float16Vector or BFloat16Vector")
 }
 
 // test create index with invalid params

--- a/test/testcases/query_test.go
+++ b/test/testcases/query_test.go
@@ -415,9 +415,11 @@ func TestOutputAllFields(t *testing.T) {
 		common.CheckErr(t, errFlush, true)
 
 		idx, _ := entity.NewIndexHNSW(entity.L2, 8, 96)
-		for _, fieldName := range []string{"floatVec", "fp16Vec", "bf16Vec", "binaryVec"} {
+		for _, fieldName := range []string{"floatVec", "fp16Vec", "bf16Vec"} {
 			_ = mc.CreateIndex(ctx, collName, fieldName, idx, false)
 		}
+		binIdx, _ := entity.NewIndexBinFlat(entity.JACCARD, 16)
+		_ = mc.CreateIndex(ctx, collName, "binaryVec", binIdx, false)
 
 		// Load collection
 		errLoad := mc.LoadCollection(ctx, collName, false)

--- a/test/testcases/resource_group_test.go
+++ b/test/testcases/resource_group_test.go
@@ -414,7 +414,7 @@ func TestTransferReplicaInvalidReplicaNumber(t *testing.T) {
 	invalidReplicas := []invalidReplicasStruct{
 		{replicaNumber: 0, errMsg: "invalid parameter[expected=NumReplica > 0][actual=invalid NumReplica 0]"},
 		{replicaNumber: -1, errMsg: "invalid parameter[expected=NumReplica > 0][actual=invalid NumReplica -1]"},
-		{replicaNumber: 1, errMsg: "only found [0] replicas in source resource group"},
+		{replicaNumber: 1, errMsg: "Collection not loaded"},
 	}
 
 	for _, invalidReplica := range invalidReplicas {


### PR DESCRIPTION
HNSW support on binary vector field is not supported. Change case behavior and skip some cases due to previously reported bug.