### PR TITLE
fix: Sync default partition number to 16

### DIFF
--- a/test/common/utils.go
+++ b/test/common/utils.go
@@ -75,7 +75,7 @@ const (
 	DefaultRgCapacity       = 1000000
 	RetentionDuration       = 40   // common.retentionDuration
 	MaxCapacity             = 4096 // max array capacity
-	DefaultPartitionNum     = 64   // default num_partitions
+	DefaultPartitionNum     = 16   // default num_partitions
 	MaxTopK                 = 16384
 	MaxVectorFieldNum       = 4
 )


### PR DESCRIPTION
See also milvus-io/milvus#32950

Default partition number is updated to 16 which caused some case failed