### PR TITLE
fix: Set dimension for Vector column `Slice` method

### DIFF
--- a/entity/columns_vector_gen.go
+++ b/entity/columns_vector_gen.go
@@ -41,6 +41,7 @@ func (c *ColumnBinaryVector) Slice(start, end int) Column {
 	return &ColumnBinaryVector{
 		ColumnBase: c.ColumnBase,
 		name:       c.name,
+		dim:		c.dim,
 		values:     c.values[start:end],
 	}
 }
@@ -152,6 +153,7 @@ func (c *ColumnFloatVector) Slice(start, end int) Column {
 	return &ColumnFloatVector{
 		ColumnBase: c.ColumnBase,
 		name:       c.name,
+		dim:		c.dim,
 		values:     c.values[start:end],
 	}
 }
@@ -239,6 +241,7 @@ func (c *ColumnFloat16Vector) Slice(start, end int) Column {
 	return &ColumnFloat16Vector{
 		ColumnBase: c.ColumnBase,
 		name:       c.name,
+		dim:		c.dim,
 		values:     c.values[start:end],
 	}
 }
@@ -337,6 +340,7 @@ func (c *ColumnBFloat16Vector) Slice(start, end int) Column {
 	return &ColumnBFloat16Vector{
 		ColumnBase: c.ColumnBase,
 		name:       c.name,
+		dim:		c.dim,
 		values:     c.values[start:end],
 	}
 }


### PR DESCRIPTION
Preventing sliced column with dim=0