### PR TITLE
fix broken Grant() call

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -202,7 +202,7 @@ type Client interface {
 	// ListGrants lists all assigned privileges and objects for the role.
 	ListGrants(ctx context.Context, role string, dbName string) ([]entity.RoleGrants, error)
 	// Grant adds privilege for role.
-	Grant(ctx context.Context, role string, objectType entity.PriviledgeObjectType, object string) error
+	Grant(ctx context.Context, role string, objectType entity.PriviledgeObjectType, object string, privilege string) error
 	// Revoke removes privilege from role.
 	Revoke(ctx context.Context, role string, objectType entity.PriviledgeObjectType, object string) error
 

--- a/client/rbac.go
+++ b/client/rbac.go
@@ -320,7 +320,7 @@ func (c *GrpcClient) ListGrant(ctx context.Context, role string, object string, 
 }
 
 // Grant adds object privileged for role.
-func (c *GrpcClient) Grant(ctx context.Context, role string, objectType entity.PriviledgeObjectType, object string) error {
+func (c *GrpcClient) Grant(ctx context.Context, role string, objectType entity.PriviledgeObjectType, object string, privilege string) error {
 	if c.Service == nil {
 		return ErrClientNotReady
 	}
@@ -332,6 +332,11 @@ func (c *GrpcClient) Grant(ctx context.Context, role string, objectType entity.P
 			},
 			Object: &milvuspb.ObjectEntity{
 				Name: commonpb.ObjectType_name[int32(objectType)],
+			},
+			Grantor: &milvuspb.GrantorEntity{
+				Privilege: &milvuspb.PrivilegeEntity{
+					Name: privilege,
+				},
 			},
 			ObjectName: object,
 		},

--- a/client/rbac_test.go
+++ b/client/rbac_test.go
@@ -629,6 +629,7 @@ func (s *RBACSuite) TestGrant() {
 	roleName := "testRole"
 	objectName := testCollectionName
 	objectType := entity.PriviledegeObjectTypeCollection
+	privilegeName := "testPrivilege"
 
 	s.Run("normal run", func() {
 		ctx, cancel := context.WithCancel(ctx)
@@ -641,7 +642,7 @@ func (s *RBACSuite) TestGrant() {
 			s.Equal(milvuspb.OperatePrivilegeType_Grant, req.GetType())
 		}).Return(&commonpb.Status{ErrorCode: commonpb.ErrorCode_Success}, nil)
 
-		err := s.client.Grant(ctx, roleName, objectType, objectName)
+		err := s.client.Grant(ctx, roleName, objectType, objectName, privilegeName)
 
 		s.NoError(err)
 	})
@@ -652,7 +653,7 @@ func (s *RBACSuite) TestGrant() {
 		defer s.resetMock()
 		s.mock.EXPECT().OperatePrivilege(mock.Anything, mock.Anything).Return(nil, errors.New("mock error"))
 
-		err := s.client.Grant(ctx, roleName, objectType, objectName)
+		err := s.client.Grant(ctx, roleName, objectType, objectName, privilegeName)
 		s.Error(err)
 	})
 
@@ -662,7 +663,7 @@ func (s *RBACSuite) TestGrant() {
 		defer s.resetMock()
 		s.mock.EXPECT().OperatePrivilege(mock.Anything, mock.Anything).Return(&commonpb.Status{ErrorCode: commonpb.ErrorCode_UnexpectedError}, nil)
 
-		err := s.client.Grant(ctx, roleName, objectType, objectName)
+		err := s.client.Grant(ctx, roleName, objectType, objectName, privilegeName)
 		s.Error(err)
 	})
 
@@ -671,7 +672,7 @@ func (s *RBACSuite) TestGrant() {
 		defer cancel()
 
 		c := &GrpcClient{}
-		err := c.Grant(ctx, roleName, objectType, objectName)
+		err := c.Grant(ctx, roleName, objectType, objectName, privilegeName)
 		s.Error(err)
 		s.ErrorIs(err, ErrClientNotReady)
 	})


### PR DESCRIPTION
The latest version of the SDK doesn't pass the actual privilege that is granted during a Grant() call. This causes the Grant call to fail in any situation. 

This PR fixes this issue by extending the method signature to take a `privilege` parameter, similarly to how the Python SDK does. This was an easy fix because the protobuf structs already had the field in place, so the SDK only needs to use that correct field in the API call.