### PR TITLE
custom attributes that can be used for altering a collection

### DIFF
--- a/client/iterator.go
+++ b/client/iterator.go
@@ -79,7 +79,7 @@ type SearchIterator struct {
 	client *GrpcClient
 }
 
-func (itr SearchIterator) init(ctx context.Context) error {
+func (itr *SearchIterator) init(ctx context.Context) error {
 	if itr.batchSize <= 0 {
 		return errors.New("batch size cannot less than 1")
 	}

--- a/entity/collection_attr.go
+++ b/entity/collection_attr.go
@@ -177,3 +177,27 @@ func (ca databaseResourceGroupsAttr) Valid() error {
 
 	return nil
 }
+
+type customAttr struct {
+	collAttrBase
+}
+
+// CustomAttribute returns a collection attribute with custom key and value
+func CustomAttribute(key, value string) customAttr {
+	ca := customAttr{}
+	ca.key = key
+	ca.value = value
+	return ca
+}
+
+// Valid implements CollectionAttribute
+// Custom attributes are considered valid as long as both key and value are non-empty
+func (ca customAttr) Valid() error {
+	if ca.key == "" {
+		return errors.New("custom attribute key cannot be empty")
+	}
+	if ca.value == "" {
+		return errors.New("custom attribute value cannot be empty")
+	}
+	return nil
+}

--- a/entity/collection_attr_test.go
+++ b/entity/collection_attr_test.go
@@ -179,3 +179,47 @@ func (s *CollectionPartitionKeyIsolationSuite) TestCollectionAutoCompactionEnabl
 func TestCollectionPartitionKeyIsolationAttr(t *testing.T) {
 	suite.Run(t, new(CollectionPartitionKeyIsolationSuite))
 }
+
+type CustomAttributeSuite struct {
+	suite.Suite
+}
+
+func (s *CustomAttributeSuite) TestValid() {
+	type testCase struct {
+		key       string
+		value     string
+		expectErr bool
+	}
+
+	cases := []testCase{
+		{key: "custom.key", value: "value", expectErr: false},
+		{key: "", value: "value", expectErr: true},
+		{key: "custom.key", value: "", expectErr: true},
+		{key: "", value: "", expectErr: true},
+	}
+
+	for _, tc := range cases {
+		s.Run(fmt.Sprintf("key=%s,value=%s", tc.key, tc.value), func() {
+			ca := CustomAttribute(tc.key, tc.value)
+			err := ca.Valid()
+			if tc.expectErr {
+				s.Error(err)
+			} else {
+				s.NoError(err)
+			}
+		})
+	}
+}
+
+func (s *CustomAttributeSuite) TestKeyValue() {
+	key := "custom.test.key"
+	value := "test.value"
+	ca := CustomAttribute(key, value)
+	gotKey, gotValue := ca.KeyValue()
+	s.Equal(key, gotKey)
+	s.Equal(value, gotValue)
+}
+
+func TestCustomAttribute(t *testing.T) {
+	suite.Run(t, new(CustomAttributeSuite))
+}


### PR DESCRIPTION
This PR allows for the altering (AlterCollection) of custom properties/attributes on a Milvus collection. The CreateCollection method already allows the setting of custom properties on the collection, but the AlterCollection did not. This PR fixes this discrepancy. This behaviour is also supported in the Python SDK.